### PR TITLE
Updates spec and fixes solution for problem 1.05

### DIFF
--- a/lib/ch01/1.05.rb
+++ b/lib/ch01/1.05.rb
@@ -1,18 +1,36 @@
 # One Away
 
 def one_away(init, final)
-  letter_diff = Hash.new(0)
+  return true if init == final
 
-  if (init.length - final.length).abs > 1
-    return false
-  else
-    init.length.times { |i| letter_diff[init[i]] += 1 }
-    final.length.times { |i| letter_diff[init[i]] -= 1 }
-    letter_diff.keys.each do |letter|
-      letter_diff.delete(letter) if letter_diff[letter] == 0
+  length_difference = init.length - final.length
+  length_difference_abs = length_difference.abs
+
+  if length_difference_abs == 0
+    # must be one away by replacement
+    letter_diff_count = 0.upto(init.length).count {|i| init[i] != final[i]}
+    letter_diff_count <= 1
+  elsif length_difference_abs == 1
+    # must be one away by insertion
+    shortest_string = length_difference < 0 ? init : final
+    longest_string = length_difference > 0 ? init : final
+    short_index = 0
+    long_index = 0
+
+    while short_index < shortest_string.length && long_index < longest_string.length
+      if shortest_string[short_index] == longest_string[long_index]
+        short_index += 1
+        long_index += 1
+      elsif short_index == long_index
+        # skip one letter in longest string the first time chars don't match
+        long_index += 1
+      else
+        return false
+      end
     end
-    return false if letter_diff.length > 1
-  end
 
-  return true
+    true
+  else
+    false
+  end 
 end

--- a/spec/ch01/1.05_spec.rb
+++ b/spec/ch01/1.05_spec.rb
@@ -1,6 +1,9 @@
 require "ch01/1.05.rb"
 
 describe "1.5 One Away" do
+  it "returns true for 'pale', 'pale'" do
+    expect(one_away('pale', 'pale')).to eq(true)
+  end
 
   it "returns false for 'aaa', 'a'" do
     expect(one_away('aaa', 'a')).to eq(false)
@@ -8,6 +11,10 @@ describe "1.5 One Away" do
 
   it "returns true for 'pale', 'ple'" do
     expect(one_away('pale', 'ple')).to eq(true)
+  end
+
+  it "returns true for 'ple', 'pale'" do
+    expect(one_away('ple', 'pale')).to eq(true)
   end
 
   it "returns true for 'pales', 'pale'" do
@@ -19,7 +26,11 @@ describe "1.5 One Away" do
   end
 
   it "returns false for 'pale', 'bake'" do
-    expect(one_away('pale', 'bake')).to eq(true)
+    expect(one_away('pale', 'bake')).to eq(false)
+  end
+
+  it "returns false for 'pale', 'elp'" do
+    expect(one_away('pale', 'elp')).to eq(false)
   end
 
 end


### PR DESCRIPTION
Added spec for `one_away('pale', 'elp')`, which should return `false` but was returning `true`.

Updated solution to make it pass the new spec.

Added another spec to check `one_away('ple', 'pale')` to make sure that the function is independent of the order of arguments (I initially had a bug that caused this to fail).